### PR TITLE
Allow writing in candidates

### DIFF
--- a/templates/vote/index.html
+++ b/templates/vote/index.html
@@ -108,63 +108,62 @@
 			</div><br/>
 			<main class="mdl-layout__content">
 			<div class="main-card-holder">
-			<div class="main-card-wide mdl-card mdl-shadow--2dp">
-				<div class="mdl-card__title">
-					<h2 class="mdl-card__title-text">Welcome</h2>
+				<div class="main-card-wide mdl-card mdl-shadow--2dp">
+					<div class="mdl-card__title">
+						<h2 class="mdl-card__title-text">Welcome</h2>
+					</div>
+					<div class="mdl-card__supporting-text">This year, the CollegiumV council elections will take place online.  To begin, drag the candidates into your preferred voting order, with the candidate you most want to win at the top.<br/><br/>Results will be determined via the Austrailian Dropbear-Kangaroo System.</div>
 				</div>
-				<div class="mdl-card__supporting-text">This year, the CollegiumV council elections will take place online.  To begin, drag the candidates into your preferred voting order, with the candidate you most want to win at the top.<br/><br/>Results will be determined via the Austrailian Dropbear-Kangaroo System.</div>
-			</div>
-			<div class="main-card-small mdl-card mdl-shadow--2dp card-left">
+				<div class="main-card-small mdl-card mdl-shadow--2dp card-left">
 
-				<div class="mdl-card__title">
-					<h2 class="mdl-card__title-text">Candidates List</h2>
-				</div>
-				<div class="mdl-card__supporting-text voting-text-block">
-					<ul id="sortable-first" class="block__list block__list_words">
-						{% for candidate in candidate_list %}
-						<li data-id="{{ candidate.id }}" class=list-group-item id="candidate{{ candidate.id }}" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> {{ candidate.name }}</li>
-						{% endfor %}
-						{% if candidate_list %}
+					<div class="mdl-card__menu">
+						<button class="mdl-button mdl-button--icon mdl-js-button" id="add-button">
+							<div class="material-icons" id="add-it">add</div>
+						</button>
+						<div class="mdl-tooltip" for="add-button">
+							<b>Write-in a candidate</b>
+						</div>
+					</div>
+					<div class="mdl-card__title">
+						<h2 class="mdl-card__title-text">Candidates List</h2>
+					</div>
+					<div class="mdl-card__supporting-text voting-text-block">
+						<ul id="sortable-first" class="block__list block__list_words">
+							{% for candidate in candidate_list %}
+							<li data-id="{{ candidate.id }}" class="list-group-item" id="candidate{{ candidate.id }}" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> {{ candidate.name }}</li>
+							{% endfor %}
+							{% if candidate_list %}
 
-						{% else %}
-						<p>No Candidates Available</p>
-						{% endif %}
-						<!-- Accent-colored raised button with ripple -->
-				</div>
-			</div>
-
-			<div class="main-card-small mdl-card mdl-shadow--2dp card-right">
-
-				<div class="mdl-card__menu">
-					<button class="mdl-button mdl-button--icon mdl-js-button" id="add-button">
-						<div class="material-icons" id="add-it">add</div>
-					</button>
-					<div class="mdl-tooltip" for="add-button">
-						<b>Write-in a candidate</b>
+							{% else %}
+							<p>No Candidates Available</p>
+							{% endif %}
 					</div>
 				</div>
-				<div class="mdl-card__title">
-					<h2 class="mdl-card__title-text">Vote</h2>
-				</div>
-				<div class="mdl-card__supporting-text voting-text-block">
-					<ul id="sortable" class="block__list block__list_words">
-						{% for candidate in candidate_list %}
-						<!--li data-id="{{ candidate.id }}" class=list-group-item id="candidate{{ candidate.id }}" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> {{ candidate.name }}</li-->
-						{% endfor %}
-						{% if candidate_list %}
 
-						{% else %}
-						<p>No Candidates Available</p>
-						{% endif %}
-						<!-- Accent-colored raised button with ripple -->
+				<div class="main-card-small mdl-card mdl-shadow--2dp card-right">
+
+					<div class="mdl-card__title">
+						<h2 class="mdl-card__title-text">Vote</h2>
+					</div>
+					<div class="mdl-card__supporting-text voting-text-block">
+						<ul id="sortable" class="block__list block__list_words">
+							{% for candidate in candidate_list %}
+							<!--li data-id="{{ candidate.id }}" class=list-group-item id="candidate{{ candidate.id }}" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> {{ candidate.name }}</li-->
+							{% endfor %}
+							{% if candidate_list %}
+
+							{% else %}
+							<p>No Candidates Available</p>
+							{% endif %}
+							<!-- Accent-colored raised button with ripple -->
+					</div>
+					<div class="mdl-card__actions mdl-card--border">
+						{% csrf_token %}
+						<a id="justDoIt" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+							Submit
+						</a>
+					</div>
 				</div>
-				<div class="mdl-card__actions mdl-card--border">
-					{% csrf_token %}
-					<a id="justDoIt" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
-						Submit
-					</a>
-				</div>
-			</div>
 			</div>
 			</main>
 		</div>
@@ -235,8 +234,36 @@ document.getElementById('add-button').onclick = function(){
 			swal.showInputError("You need to write something!");
 			return false
 		}
+		var sendThing = sortable.toArray().join(',');
 
-		swal("Nice!", "You wrote: " + inputValue, "success");
+		var xmlhttp;
+		var params = "csrfmiddlewaretoken=" + document.getElementsByName("csrfmiddlewaretoken")[0].value + "&name=" + inputValue;
+
+		xmlhttp = new XMLHttpRequest();
+		xmlhttp.onreadystatechange = function() {
+			if (xmlhttp.readyState == XMLHttpRequest.DONE ) {
+				if(xmlhttp.status == 200){
+					swal("Added!", inputValue + " has been added to the Candidates List ", "success")
+					candidateID = xmlhttp.response;
+					document.getElementById('sortable-first').innerHTML = '<li data-id="'+candidateID+'" class="list-group-item" id="candidate'+candidateID+'" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> '+inputValue+'</li>'+document.getElementById('sortable-first').innerHTML;
+				}
+				else if(xmlhttp.status == 409){
+					swal("Duplicate Entry", inputValue + " already exists in the Candidates List.", "error")
+				}
+				else if(xmlhttp.status == 418){		//teapot
+					swal("Invalid Write-In", inputValue + " may not be written in.", "error")
+				}
+				else{
+					swal("Oops...", "Your write-in encountered an error.  " + xmlhttp.status, "error");
+				}
+			}
+		}
+
+		xmlhttp.open("POST", "/vote/add", true);
+		//xmlhttp.open("POST","http://httpstat.us/200", true);
+		xmlhttp.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+		xmlhttp.send(params);
+
 	});
 }
 	</script>

--- a/templates/vote/index.html
+++ b/templates/vote/index.html
@@ -26,15 +26,18 @@
 	vertical-align:middle;
 	height:30px;
 	font-size:16px;
+	background-origin:padding-box;
+	position:relative;
+	z-index:3;
 }
 .block__list li:hover{
 	transition:.4s;
 	background-color: #e3f2fd;
 }
 .block__list_words .sortable-ghost {
-	color: #FFFFFF;
-	background-color: #2196F3;
-	opacity:0.6;
+	color: #FEFEFF;
+	background-color: #7ac0f8;
+	opacity:1;
 }
 .voting-text-block {
 	width:100%;
@@ -80,6 +83,17 @@
 .card-left{
 	float:left;
 }
+
+#dragInstruction{
+	text-align:center;
+	position:static;
+	height:70px;
+	margin-bottom:-70px;
+	font-size:16px;
+	vertical-align:middle;
+	z-index:2;
+	line-height:70px;
+}
 		</style>
 	</head>
 	<body>
@@ -112,7 +126,7 @@
 					<div class="mdl-card__title">
 						<h2 class="mdl-card__title-text">Welcome</h2>
 					</div>
-					<div class="mdl-card__supporting-text">This year, the CollegiumV council elections will take place online.  To begin, drag the candidates into your preferred voting order, with the candidate you most want to win at the top.<br/><br/>Results will be determined via the Austrailian Dropbear-Kangaroo System.</div>
+					<div class="mdl-card__supporting-text">This year, the CollegiumV council elections will take place online.  To begin, drag the candidates you would like from the left list to the right list into your preferred voting order, with the candidate you most want to win at the top of the right list.<br/><br/>Results will be determined via the Austrailian Dropbear-Kangaroo System.</div>
 				</div>
 				<div class="main-card-small mdl-card mdl-shadow--2dp card-left">
 
@@ -146,16 +160,15 @@
 						<h2 class="mdl-card__title-text">Vote</h2>
 					</div>
 					<div class="mdl-card__supporting-text voting-text-block">
-						<ul id="sortable" class="block__list block__list_words">
-							{% for candidate in candidate_list %}
-							<!--li data-id="{{ candidate.id }}" class=list-group-item id="candidate{{ candidate.id }}" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> {{ candidate.name }}</li-->
-							{% endfor %}
-							{% if candidate_list %}
 
+						{% if candidate_list %}
+						<div id="dragInstruction">Drag candidates from the left list</div>
+						<ul id="sortable" class="block__list block__list_words">
 							{% else %}
-							<p>No Candidates Available</p>
-							{% endif %}
-							<!-- Accent-colored raised button with ripple -->
+							<ul id="sortable" class="block__list block__list_words">
+								<p>No Candidates Available</p>
+								{% endif %}
+								<!-- Accent-colored raised button with ripple -->
 					</div>
 					<div class="mdl-card__actions mdl-card--border">
 						{% csrf_token %}
@@ -244,7 +257,7 @@ document.getElementById('add-button').onclick = function(){
 			if (xmlhttp.readyState == XMLHttpRequest.DONE ) {
 				if(xmlhttp.status == 200){
 					swal("Added!", inputValue + " has been added to the Candidates List ", "success")
-					candidateID = xmlhttp.response;
+						candidateID = xmlhttp.response;
 					document.getElementById('sortable-first').innerHTML = '<li data-id="'+candidateID+'" class="list-group-item" id="candidate'+candidateID+'" class="ui-state-default"><span class="drag-handle"><i class="material-icons">reorder</i></span> '+inputValue+'</li>'+document.getElementById('sortable-first').innerHTML;
 				}
 				else if(xmlhttp.status == 409){

--- a/views.py
+++ b/views.py
@@ -12,10 +12,7 @@ from .models import Candidate, Vote
 def index(request):
     candidate_list = Candidate.objects.all()
     template = loader.get_template('vote/index.html')
-    context = RequestContext(request, {
-        'candidate_list': candidate_list,
-    })
-    return HttpResponse(template.render(context))
+    return HttpResponse(template.render({'candidate_list': candidate_list}, request))
 
 def faq(request):
     return HttpResponse("FAQ")


### PR DESCRIPTION
Pressing the plus button by the Candidates List will pop up a box allowing users to enter in a custom name.  Hitting enter will then send a POST request to /vote/add.  Responses are as follows.

**200 (OK)**
- The user will be notified that their candidate write-in was okay.  The
  candidate will be appended to the top of the sortable candidates list
  (on the left).  The data-id of this li will be the entire reponse
  body.  Please ensure that the entire respone body is the candidate's
  id.

**409 (Conflict)**
- The user will be notified that their candidate already exists in the
  candidate list.  No further action will be taken.

**418 (I'm a teapot)**
- The user will be notified that their write-in was not a valid user.
  This is intended for joke votes.

**Anything else**
- The user will be notified that their write-in has encountered an
  error, along with the HTTP status code.  This is intended for
  miscellaneous server issues.

Note that line 263 of templates/vote/index.html is commented out, but would point the POST request to http://httpstat.us.  This can be used to test things.
