### PR TITLE
Make the results list taller

### DIFF
--- a/templates/vote/index.html
+++ b/templates/vote/index.html
@@ -18,7 +18,7 @@
 	list-style: none;
 	margin:0;
 	padding:0;
-	min-height: 70px;
+	min-height: 900px;
 }
 .block__list li{
 	transition:.4s;


### PR DESCRIPTION
Candidate list is too tall.  This makes it slightly easier to drag
people from the bottom of the candidates list to the vote list.

Fixing in production aww yeah.
